### PR TITLE
Change default theme of the docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,7 +1,10 @@
 export default {
     title: "Django Forbid",
     description: "Manage access to your Django apps",
-    head: [["link", {rel: "icon", type: "image/x-icon", href: "/logo.png"}]],
+    head: [
+        ["link", {rel: "icon", type: "image/x-icon", href: "/logo.png"}],
+        ["link", {href: "/index.css", rel: "stylesheet"}],
+    ],
     cleanUrls: true,
     lang: "en-US",
     base: "/django-forbid/",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "serve": "vitepress serve"
   },
   "dependencies": {
-    "vitepress": "^1.0.0-alpha.75",
+    "vitepress": "^1.0.0-rc.4",
     "vue": "^3.3.2"
   }
 }

--- a/docs/public/index.css
+++ b/docs/public/index.css
@@ -1,0 +1,11 @@
+:root {
+    --vp-c-brand: rgb(68, 183, 139);
+    --vp-c-brand-light: var(--vp-c-brand);
+    --vp-c-brand-lighter: var(--vp-c-brand);
+    --vp-c-brand-lightest: var(--vp-c-brand);
+    --vp-c-brand-dark: var(--vp-c-brand);
+    --vp-c-brand-darker: rgba(68, 183, 139, 0.8);
+
+    --vp-button-brand-bg: var(--vp-c-brand);
+    --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+}


### PR DESCRIPTION
### Motivation:

VitePress has moved from alpha versions to beta and changed the primary color of the default theme to blue. This PR defines a custom color scheme and upgrades the VitePress version to the latest one.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
